### PR TITLE
Patch-level upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <cassandra-unit-spring.version>3.3.0.2</cassandra-unit-spring.version>
         <couchmove.version>1.0.1</couchmove.version>
         <couchbase-testcontainer.version>1.0</couchbase-testcontainer.version>
-        <cucumber.version>1.2.4</cucumber.version>
+        <cucumber.version>1.2.5</cucumber.version>
         <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
         <gatling.version>2.2.5</gatling.version>
         <guava.version>23.0</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <hazelcast-hibernate52.version>1.2.2</hazelcast-hibernate52.version>
         <hazelcast-wm.version>3.7.1</hazelcast-wm.version>
         <hibernate.version>5.2.12.Final</hibernate.version>
-        <hikaricp.version>2.6.0</hikaricp.version>
+        <hikaricp.version>2.6.3</hikaricp.version>
         <infinispan-cloud.version>9.0.0.Final</infinispan-cloud.version>
         <infinispan-spring-boot-starter.version>1.0.0.Final</infinispan-spring-boot-starter.version>
         <jhipster-server.version>1.1.13</jhipster-server.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <mssql-jdbc.version>6.1.0.jre8</mssql-jdbc.version>
         <oracle-jdbc.version>12.1.0.2</oracle-jdbc.version>
         <problem-spring-web.version>0.22.0</problem-spring-web.version>
-        <prometheus-simpleclient.version>0.0.20</prometheus-simpleclient.version>
+        <prometheus-simpleclient.version>0.0.26</prometheus-simpleclient.version>
         <!-- The spring-boot version should match the one in
         https://github.com/spring-io/platform/blob/v${project.parent.version}/platform-bom/pom.xml -->
         <spring-boot.version>1.5.7.RELEASE</spring-boot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <guava.version>23.0</guava.version>
         <hazelcast-hibernate52.version>1.2.2</hazelcast-hibernate52.version>
         <hazelcast-wm.version>3.7.1</hazelcast-wm.version>
-        <hibernate.version>5.2.10.Final</hibernate.version>
+        <hibernate.version>5.2.12.Final</hibernate.version>
         <hikaricp.version>2.6.0</hikaricp.version>
         <infinispan-cloud.version>9.0.0.Final</infinispan-cloud.version>
         <infinispan-spring-boot-starter.version>1.0.0.Final</infinispan-spring-boot-starter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <!-- Dependency versions -->
         <assertj.version>3.8.0</assertj.version>
         <bucket4j.version>3.0.2</bucket4j.version>
-        <cassandra-driver.version>3.3.0</cassandra-driver.version>
+        <cassandra-driver.version>3.3.1</cassandra-driver.version>
         <cassandra-unit-spring.version>3.3.0.2</cassandra-unit-spring.version>
         <couchmove.version>1.0.1</couchmove.version>
         <couchbase-testcontainer.version>1.0</couchbase-testcontainer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <mongobee.version>0.12</mongobee.version>
         <mssql-jdbc.version>6.1.0.jre8</mssql-jdbc.version>
         <oracle-jdbc.version>12.1.0.2</oracle-jdbc.version>
-        <problem-spring-web.version>0.21.0</problem-spring-web.version>
+        <problem-spring-web.version>0.22.0</problem-spring-web.version>
         <prometheus-simpleclient.version>0.0.20</prometheus-simpleclient.version>
         <!-- The spring-boot version should match the one in
         https://github.com/spring-io/platform/blob/v${project.parent.version}/platform-bom/pom.xml -->

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <hazelcast-wm.version>3.7.1</hazelcast-wm.version>
         <hibernate.version>5.2.12.Final</hibernate.version>
         <hikaricp.version>2.6.3</hikaricp.version>
-        <infinispan-cloud.version>9.0.0.Final</infinispan-cloud.version>
+        <infinispan-cloud.version>9.0.3.Final</infinispan-cloud.version>
         <infinispan-spring-boot-starter.version>1.0.0.Final</infinispan-spring-boot-starter.version>
         <jhipster-server.version>1.1.13</jhipster-server.version>
         <jjwt.version>0.7.0</jjwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <!-- Dependency versions -->
         <assertj.version>3.8.0</assertj.version>
-        <bucket4j.version>3.0.1</bucket4j.version>
+        <bucket4j.version>3.0.2</bucket4j.version>
         <cassandra-driver.version>3.3.0</cassandra-driver.version>
         <cassandra-unit-spring.version>3.3.0.2</cassandra-unit-spring.version>
         <couchmove.version>1.0.1</couchmove.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <couchmove.version>1.0.1</couchmove.version>
         <couchbase-testcontainer.version>1.0</couchbase-testcontainer.version>
         <cucumber.version>1.2.5</cucumber.version>
-        <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
+        <dropwizard-metrics.version>3.2.5</dropwizard-metrics.version>
         <gatling.version>2.2.5</gatling.version>
         <guava.version>23.0</guava.version>
         <hazelcast-hibernate52.version>1.2</hazelcast-hibernate52.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <dropwizard-metrics.version>3.2.5</dropwizard-metrics.version>
         <gatling.version>2.2.5</gatling.version>
         <guava.version>23.0</guava.version>
-        <hazelcast-hibernate52.version>1.2</hazelcast-hibernate52.version>
+        <hazelcast-hibernate52.version>1.2.2</hazelcast-hibernate52.version>
         <hazelcast-wm.version>3.7</hazelcast-wm.version>
         <hibernate.version>5.2.10.Final</hibernate.version>
         <hikaricp.version>2.6.0</hikaricp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <gatling.version>2.2.5</gatling.version>
         <guava.version>23.0</guava.version>
         <hazelcast-hibernate52.version>1.2.2</hazelcast-hibernate52.version>
-        <hazelcast-wm.version>3.7</hazelcast-wm.version>
+        <hazelcast-wm.version>3.7.1</hazelcast-wm.version>
         <hibernate.version>5.2.10.Final</hibernate.version>
         <hikaricp.version>2.6.0</hikaricp.version>
         <infinispan-cloud.version>9.0.0.Final</infinispan-cloud.version>


### PR DESCRIPTION
This is just about the last bit of stuff I wanted to hand over before I have to start with my "day job" project tomorrow: some dependency upgrades.

This PR only updates patch releases, but there are also a few dependencies that have minor-level updates available. I've kept those separately, so if you want them they are here:
https://github.com/erikkemperman/jhipster-dependencies/tree/upgrades-minor (note, I've commited those _on top_ of the commits in this PR).

But I guess we should figure out a way to test these in the generator without going ahead and releasing jhipster-dependencies and then having to resolve any issues that may come up afterward?

Finally, there's also an update to mongobee available, but I seem to remember it causing trouble earlier... Were those issues resolved in the mean time?