### PR TITLE
Exclude hibernate-entitymanager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,18 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-data-jpa</artifactId>
+                <!-- This exclusion will not be needed with spring-boot 2 -->
+                <!-- See https://github.com/spring-projects/spring-boot/pull/8433 -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hibernate</groupId>
+                        <artifactId>hibernate-entitymanager</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-thymeleaf</artifactId>
                 <version>${spring-boot.version}</version>
                 <exclusions>


### PR DESCRIPTION
This artifact is no longer needed, included in hibernate-core. But it pulls in the large byte-buddy jar unnecessarily.

The exclusion will not be needed with spring-boot 2, see https://github.com/spring-projects/spring-boot/issues/7557.