### PR TITLE
upgrade hazelcast version to 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <gatling.version>2.2.5</gatling.version>
         <guava.version>23.0</guava.version>
         <hazelcast-hibernate52.version>1.2.2</hazelcast-hibernate52.version>
-        <hazelcast-wm.version>3.7.1</hazelcast-wm.version>
+        <hazelcast-wm.version>3.9</hazelcast-wm.version>
         <hibernate.version>5.2.12.Final</hibernate.version>
         <hikaricp.version>2.6.3</hikaricp.version>
         <infinispan-cloud.version>9.0.3.Final</infinispan-cloud.version>


### PR DESCRIPTION
support hazelcast management center. old hazelcast (version 3.7.1) not support .