### PR TITLE
removed duplicated spring-boot-starter-thymeleaf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,17 +377,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-thymeleaf</artifactId>
-                <version>${spring-boot.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>nz.net.ultraq.thymeleaf</groupId>
-                        <artifactId>thymeleaf-layout-dialect</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.springframework.social</groupId>
                 <artifactId>spring-social-google</artifactId>
                 <version>${spring-social-google.version}</version>


### PR DESCRIPTION
Due to the duplicate spring-boot-starter-thymeleaf dependecy, the build has a warning message below:

[WARNING] 
[WARNING] Some problems were encountered while building the effective model for hu.sonrisa.gears:consultant-tool:war:0.0.1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.springframework.boot:spring-boot-starter-thymeleaf:jar -> duplicate declaration of version ${spring-boot.version} @ io.github.jhipster:jhipster-dependencies:0.1.0, /Users/agaton/.m2/repository/io/github/jhipster/jhipster-dependencies/0.1.0/jhipster-dependencies-0.1.0.pom, line 379, column 25
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]