### PR TITLE
Fix hazelcast upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,9 @@
         <dropwizard-metrics.version>3.2.5</dropwizard-metrics.version>
         <gatling.version>2.2.5</gatling.version>
         <guava.version>23.0</guava.version>
+        <hazelcast.version>3.9</hazelcast.version>
         <hazelcast-hibernate52.version>1.2.2</hazelcast-hibernate52.version>
-        <hazelcast-wm.version>3.9</hazelcast-wm.version>
+        <hazelcast-wm.version>3.8.3</hazelcast-wm.version>
         <hibernate.version>5.2.12.Final</hibernate.version>
         <hikaricp.version>2.6.3</hikaricp.version>
         <infinispan-cloud.version>9.0.3.Final</infinispan-cloud.version>


### PR DESCRIPTION
Commit https://github.com/jhipster/jhipster-dependencies/commit/9bcab17bf6344db30ae680bccadf6851ea202964 changed the wrong property, and ended up not updating hazelcast and pointing hazelcast-wm to a non-existent release...

