### PR TITLE
Upgrade spring-cloud to Edgware

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,11 +91,8 @@
         <!-- The spring-boot version should match the one in
         https://github.com/spring-io/platform/blob/v${project.parent.version}/platform-bom/pom.xml -->
         <spring-boot.version>1.5.9.RELEASE</spring-boot.version>
-        <spring-cloud.version>Dalston.SR4</spring-cloud.version>
-        <!-- The netflix version should match the one in
-        https://github.com/spring-cloud/spring-cloud-release/blob/v${spring-cloud.version}/spring-cloud-dependencies/pom.xml -->
-        <spring-cloud-netflix.version>1.3.5.RELEASE</spring-cloud-netflix.version>
-        <spring-cloud-stream.version>Chelsea.SR2</spring-cloud-stream.version>
+        <spring-cloud.version>Edgware.RELEASE</spring-cloud.version>
+        <spring-cloud-netflix.version>1.4.0.RELEASE</spring-cloud-netflix.version>
         <spring-social-google.version>1.0.0.RELEASE</spring-social-google.version>
         <springfox.version>2.7.0</springfox.version>
     </properties>
@@ -406,13 +403,6 @@
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring-cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-stream-dependencies</artifactId>
-                <version>${spring-cloud-stream.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
I've removed the explicit bom import for spring-cloud-stream, preferring to just inherit from spring-cloud-dependencies. We would now get, among others:
- spring-cloud-stream at [Ditmars](https://github.com/spring-cloud/spring-cloud-release/blob/vEdgware.RELEASE/spring-cloud-dependencies/pom.xml#L29)
- spring-cloud-consul at [1.3.0](https://github.com/spring-cloud/spring-cloud-release/blob/vEdgware.RELEASE/spring-cloud-dependencies/pom.xml#L23)
- spring-cloud-netflix at [1.4.0](https://github.com/spring-cloud/spring-cloud-release/blob/vEdgware.RELEASE/spring-cloud-dependencies/pom.xml#L26)

I tested this patch against in generator using the mono-repo setup, and everything passes:
https://travis-ci.org/erikkemperman/generator-jhipster/builds/312383978