### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
         <couchbase-testcontainer.version>1.0</couchbase-testcontainer.version>
         <cucumber.version>1.2.5</cucumber.version>
         <dropwizard-metrics.version>3.2.5</dropwizard-metrics.version>
-        <elasticsearch-transport-client.version>6.1.0</elasticsearch-transport-client.version>
         <gatling.version>2.2.5</gatling.version>
         <guava.version>23.5-jre</guava.version>
         <hazelcast.version>3.9.1</hazelcast.version>
@@ -95,7 +94,6 @@
         <spring-cloud.version>Finchley.M5</spring-cloud.version>
         <!-- The netflix version should match the one in
         https://github.com/spring-cloud/spring-cloud-release/blob/v${spring-cloud.version}/spring-cloud-dependencies/pom.xml -->
-        <spring-cloud-netflix.version>2.0.0.M5</spring-cloud-netflix.version>
         <spring-cloud-stream.version>Elmhurst.M3</spring-cloud-stream.version>
         <spring-social-google.version>1.0.0.RELEASE</spring-social-google.version>
         <spring-social-facebook.version>2.0.3.RELEASE</spring-social-facebook.version>
@@ -188,11 +186,6 @@
                 <groupId>com.hazelcast</groupId>
                 <artifactId>hazelcast-wm</artifactId>
                 <version>${hazelcast-wm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.elasticsearch.client</groupId>
-                <artifactId>transport</artifactId>
-                <version>${elasticsearch-transport-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
@@ -388,19 +381,19 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-starter-ribbon</artifactId>
-                <version>${spring-cloud-netflix.version}</version>
+            <!--<dependency>-->
+                <!--<groupId>org.springframework.cloud</groupId>-->
+                <!--<artifactId>spring-cloud-starter-ribbon</artifactId>-->
+                <!--<version>${spring-cloud-netflix.version}</version>-->
                 <!-- netty's native is pulled, but is useless unless you explicitly add the native binary dependency.
                      Having it in the classpath without the binary can cause warnings -->
-                <exclusions>
-                    <exclusion>
-                        <groupId>io.netty</groupId>
-                        <artifactId>netty-transport-native-epoll</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
+                <!--<exclusions>-->
+                    <!--<exclusion>-->
+                        <!--<groupId>io.netty</groupId>-->
+                        <!--<artifactId>netty-transport-native-epoll</artifactId>-->
+                    <!--</exclusion>-->
+                <!--</exclusions>-->
+            <!--</dependency>-->
             <dependency>
                 <groupId>org.springframework.social</groupId>
                 <artifactId>spring-social-google</artifactId>


### PR DESCRIPTION
- add spring-security-oauth2-autoconfigure lib for oauth single-sign-on support
- change order of managed dependency imports to get the correct version of kafka

all test are green with the related generator-jhipster:
https://travis-ci.org/michael-wirth/jhipster-dependencies