### PR TITLE
Add compatibility with Couchbase v5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <cassandra-driver.version>3.3.2</cassandra-driver.version>
         <cassandra-unit-spring.version>3.3.0.2</cassandra-unit-spring.version>
         <couchmove.version>1.0.1</couchmove.version>
-        <couchbase-testcontainer.version>1.1</couchbase-testcontainer.version>
+        <couchbase-testcontainer.version>1.11</couchbase-testcontainer.version>
         <couchbase-client.version>2.5.4</couchbase-client.version>
         <cucumber.version>1.2.5</cucumber.version>
         <dropwizard-metrics.version>3.2.5</dropwizard-metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,8 @@
         <cassandra-driver.version>3.3.2</cassandra-driver.version>
         <cassandra-unit-spring.version>3.3.0.2</cassandra-unit-spring.version>
         <couchmove.version>1.0.1</couchmove.version>
-        <couchbase-testcontainer.version>1.0</couchbase-testcontainer.version>
+        <couchbase-testcontainer.version>1.1</couchbase-testcontainer.version>
+        <couchbase-client.version>2.5.4</couchbase-client.version>
         <cucumber.version>1.2.5</cucumber.version>
         <dropwizard-metrics.version>3.2.5</dropwizard-metrics.version>
         <elasticsearch-transport-client.version>6.1.0</elasticsearch-transport-client.version>
@@ -283,6 +284,11 @@
                 <groupId>com.github.differentway</groupId>
                 <artifactId>couchmove</artifactId>
                 <version>${couchmove.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.couchbase.client</groupId>
+                <artifactId>java-client</artifactId>
+                <version>${couchbase-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.microsoft.sqlserver</groupId>


### PR DESCRIPTION
Upgrade Couchbase testcontainers to [1.1](https://github.com/differentway/testcontainers-java-module-couchbase/releases/tag/1.1)
Fix Couchbase java-client to 2.5.4 