### PR TITLE
fixing the bom to refer the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.spring.platform</groupId>
         <artifactId>platform-bom</artifactId>
-        <version>Cairo-BUILD-SNAPSHOT</version>
+        <version>Brussels-SR7</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
I think this gets lost in series of merges to master 